### PR TITLE
Starting logp calculators, implementing Crippen Method and test.

### DIFF
--- a/src/adme_py/lipophilicity.py
+++ b/src/adme_py/lipophilicity.py
@@ -4,7 +4,7 @@ from rdkit import Chem
 
 
 def calculate_logp_crippen(mol):
-    """Calculate the LogP of a molecule using Crippen Method.
+    """Calculate the LogP of a molecule using Wildman-Crippen Method.
 
     Parameters
     ----------

--- a/src/adme_py/lipophilicity.py
+++ b/src/adme_py/lipophilicity.py
@@ -1,0 +1,19 @@
+"""Calculate Lipophilicity parameters."""
+
+from rdkit import Chem
+
+
+def calculate_logp_crippen(mol):
+    """Calculate the LogP of a molecule using Crippen Method.
+
+    Parameters
+    ----------
+         mol : Chem.Mol
+              The input rdkit Mol object.
+
+    Returns
+    -------
+         result : float
+              The calculated WLogP of the molecule.
+    """
+    return Chem.Crippen.MolLogP(mol)

--- a/tests/test_lipophilicity.py
+++ b/tests/test_lipophilicity.py
@@ -1,0 +1,13 @@
+"""Test lipophilicity calculators."""
+
+from adme_py.lipophilicity import (
+    calculate_logp_crippen,
+)
+
+
+def test_calculate_logp_crippen(rdkit_mol):
+    """Test the calculation of the WLogP."""
+    mlogp_value = calculate_logp_crippen(rdkit_mol)
+    expected_value = 1.99502
+
+    assert expected_value == mlogp_value


### PR DESCRIPTION
Closes #2 

PR to add LogP calculation functionality.

- [ ] ~~Log Po/w (iLOGP)~~
- [ ] ~~Log Po/w (XLOGP3)~~
- [x] Log Po/w (WLOGP)
- [ ] ~~Log Po/w (MLOGP)~~
- [ ] ~~Log Po/w (SILICOS-IT)~~
- [ ] ~~Consensus Log Po/w~~

We need to test and see how easy some of these would be to implement. The more methods, the better the consensus becomes. `rdkit` natively includes WLOGP as SwissADME calls it. This is the Wildman-Crippen method of calculating LogP